### PR TITLE
added bind options for both service port and metrics port for spacedsust, slingshot, and ufos

### DIFF
--- a/slingshot/src/server.rs
+++ b/slingshot/src/server.rs
@@ -695,6 +695,7 @@ pub async fn serve(
     acme_contact: Option<String>,
     certs: Option<PathBuf>,
     shutdown: CancellationToken,
+    bind: std::net::SocketAddr,
 ) -> Result<(), ServerError> {
     let repo = Arc::new(repo);
     let api_service = OpenApiService::new(
@@ -752,7 +753,7 @@ pub async fn serve(
         )
         .await
     } else {
-        run(TcpListener::bind("127.0.0.1:3000"), app, shutdown).await
+        run(TcpListener::bind(bind.to_string()), app, shutdown).await
     }
 }
 

--- a/spacedust/src/server.rs
+++ b/spacedust/src/server.rs
@@ -29,6 +29,7 @@ pub async fn serve(
     b: broadcast::Sender<Arc<ClientMessage>>,
     d: broadcast::Sender<Arc<ClientMessage>>,
     shutdown: CancellationToken,
+    bind: std::net::SocketAddr,
 ) -> Result<(), ServerError> {
     let config_logging = ConfigLogging::StderrTerminal {
         level: ConfigLoggingLevel::Info,
@@ -72,7 +73,7 @@ pub async fn serve(
 
     let server = ServerBuilder::new(api, ctx, log)
         .config(ConfigDropshot {
-            bind_address: "0.0.0.0:9998".parse().unwrap(),
+            bind_address: bind,
             ..Default::default()
         })
         .start()?;

--- a/ufos/src/server/mod.rs
+++ b/ufos/src/server/mod.rs
@@ -716,7 +716,7 @@ async fn search_collections(
     .await
 }
 
-pub async fn serve(storage: impl StoreReader + 'static) -> Result<(), String> {
+pub async fn serve(storage: impl StoreReader + 'static, bind: std::net::SocketAddr) -> Result<(), String> {
     describe_metrics();
     let log = ConfigLogging::StderrTerminal {
         level: ConfigLoggingLevel::Warn,
@@ -758,7 +758,7 @@ pub async fn serve(storage: impl StoreReader + 'static) -> Result<(), String> {
 
     ServerBuilder::new(api, context, log)
         .config(ConfigDropshot {
-            bind_address: "0.0.0.0:9999".parse().unwrap(),
+            bind_address: bind,
             ..Default::default()
         })
         .start()


### PR DESCRIPTION
The clippy linting has a rule for too_many_arguments set to a max of 7, my refactored serve func for slingshot has 8 args:

```rust
pub async fn serve(
    cache: HybridCache<String, CachedRecord>,
    identity: Identity,
    repo: Repo,
    domain: Option<String>,
    acme_contact: Option<String>,
    certs: Option<PathBuf>,
    shutdown: CancellationToken,
    bind: std::net::SocketAddr,
) -> Result<(), ServerError> {
```

How do you recommend fixing this?