### PR TITLE
Make slingshot's PLC directory configurable at runtime

### DIFF
--- a/slingshot/src/identity.rs
+++ b/slingshot/src/identity.rs
@@ -22,7 +22,7 @@ use atrium_api::{
 };
 use atrium_common::resolver::Resolver;
 use atrium_identity::{
-    did::{CommonDidResolver, CommonDidResolverConfig, DEFAULT_PLC_DIRECTORY_URL},
+    did::{CommonDidResolver, CommonDidResolverConfig},
     handle::{AtprotoHandleResolver, AtprotoHandleResolverConfig, DnsTxtResolver},
 };
 use atrium_oauth::DefaultHttpClient; // it's probably not worth bringing all of atrium_oauth for this but
@@ -194,6 +194,7 @@ impl Identity {
         cache_dir: impl AsRef<Path>,
         memory_mb: usize,
         disk_gb: usize,
+        plc_directory_url: String,
     ) -> Result<Self, IdentityError> {
         let http_client = Arc::new(DefaultHttpClient::default());
         let handle_resolver = AtprotoHandleResolver::new(AtprotoHandleResolverConfig {
@@ -201,7 +202,7 @@ impl Identity {
             http_client: http_client.clone(),
         });
         let did_resolver = CommonDidResolver::new(CommonDidResolverConfig {
-            plc_directory_url: DEFAULT_PLC_DIRECTORY_URL.to_string(),
+            plc_directory_url,
             http_client: http_client.clone(),
         });
 

--- a/slingshot/src/main.rs
+++ b/slingshot/src/main.rs
@@ -7,6 +7,7 @@ use slingshot::{
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
+use atrium_identity::did::DEFAULT_PLC_DIRECTORY_URL;
 use clap::Parser;
 use tokio_util::sync::CancellationToken;
 
@@ -48,6 +49,10 @@ struct Args {
     #[arg(long, env = "SLINGSHOT_IDENTITY_CACHE_DISK_DB")]
     #[clap(default_value_t = 1)]
     identity_cache_disk_gb: usize,
+    /// the plc directory used to resolve did:plc identities
+    #[arg(long, env = "SLINGSHOT_PLC_DIRECTORY")]
+    #[clap(default_value = DEFAULT_PLC_DIRECTORY_URL)]
+    plc_directory: String,
     /// the domain pointing to this server
     ///
     /// if present:
@@ -140,6 +145,7 @@ async fn main() -> Result<(), String> {
         cache_dir.join("./identity"),
         args.identity_cache_memory_mb,
         args.identity_cache_disk_gb,
+        args.plc_directory,
     )
     .await
     .map_err(|e| format!("identity setup failed: {e:?}"))?;


### PR DESCRIPTION
Hey @uniphil, I was looking to run slingshot locally for testing purposes, and realised I can't set it to use my local-net PLC directory. This PR would make it configurable but shouldn't affect how it runs anywhere else (the default/fallback is still https://plc.directory)